### PR TITLE
preserve CDATA sections

### DIFF
--- a/etree_test.go
+++ b/etree_test.go
@@ -256,6 +256,25 @@ func TestDocumentReadNonUTF8Encodings(t *testing.T) {
 	}
 }
 
+func TestPreserveCDATA(t *testing.T) {
+	s := `<name><![CDATA[My <b>name</b> is]]></name>`
+
+	doc := NewDocument()
+	err := doc.ReadFromString(s)
+	if err != nil {
+		t.Fatalf("etree: failed to ReadFromString: %v", err)
+	}
+
+	result, err := doc.WriteToString()
+	if err != nil {
+		t.Fatalf("etree: failed to WriteToString: %v", err)
+	}
+
+	if result != s {
+		t.Errorf("etree: wanted %q, got %q", s, result)
+	}
+}
+
 func TestDocumentReadPermissive(t *testing.T) {
 	s := "<select disabled></select>"
 


### PR DESCRIPTION
Tee parser reads to a buffer to be able to inspect the raw data underlying
xml.CharData tokens so that we can see if they start with a <![CDATA[
declaration.